### PR TITLE
Make valid .docx file with equation numbering

### DIFF
--- a/pandoc_eqnos.py
+++ b/pandoc_eqnos.py
@@ -213,11 +213,11 @@ def _add_markup(fmt, eq, value):
         # As per http://officeopenxml.com/WPhyperlink.php
         bookmarkstart = \
           RawInline('openxml',
-                    '<w:bookmarkStart w:id="0" w:name="%s"/><w:r><w:t>'
+                    '<w:bookmarkStart w:id="0" w:name="%s"/>'
                     %attrs.id)
         bookmarkend = \
           RawInline('openxml',
-                    '</w:t></w:r><w:bookmarkEnd w:id="0"/>')
+                    '<w:bookmarkEnd w:id="0"/>')
         ret = [bookmarkstart, AttrMath(*value), bookmarkend]
     else:
         ret = None


### PR DESCRIPTION
Resolves #62

At the least, I've been able to produce a .docx file that opens in Google Docs. My solution was to remove what appear to be extraneous tags.