### PR TITLE
Allowing custom section separator

### DIFF
--- a/pandoc_eqnos.py
+++ b/pandoc_eqnos.py
@@ -213,11 +213,11 @@ def _add_markup(fmt, eq, value):
         # As per http://officeopenxml.com/WPhyperlink.php
         bookmarkstart = \
           RawInline('openxml',
-                    '<w:bookmarkStart w:id="0" w:name="%s"/><w:r><w:t>'
+                    '<w:bookmarkStart w:id="0" w:name="%s"/>'
                     %attrs.id)
         bookmarkend = \
           RawInline('openxml',
-                    '</w:t></w:r><w:bookmarkEnd w:id="0"/>')
+                    '<w:bookmarkEnd w:id="0"/>')
         ret = [bookmarkstart, AttrMath(*value), bookmarkend]
     else:
         ret = None


### PR DESCRIPTION
Recently, I came across a requirement to use `fig 1-1` instead of` fig 1.1`.

This PR allows custom section separator. In metadata: `xnos-section-separator: '-'` or `pandoc-section-separator: '-'` will replace the default `.` to `-`.

Notice: this PR based on #64 

Related:
- https://github.com/tomduck/pandoc-tablenos/pull/32
- https://github.com/tomduck/pandoc-fignos/pull/100